### PR TITLE
`start` > `dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ For setup, perform the following steps:
 
 After setting up, the following commands are at your hands:
 
-* `yarn start` Spawn a local development server
+* `yarn run dev` Spawn a local development server
 * `yarn run build` Build all static assets into (see `public/`)

--- a/install.js
+++ b/install.js
@@ -60,7 +60,7 @@ const existingScripts = moduleConfig.scripts || {};
 const scripts = {
   'build': 'rm -rf public/*; NODE_ENV=production webpack --progress',
   'lint': 'eslint --ignore-path .gitignore .',
-  'start': 'webpack-dev-server --progress'
+  'dev': 'webpack-dev-server --progress'
 };
 
 const injectedModuleConfig = Object.assign({}, moduleConfig, {


### PR DESCRIPTION
don't make `$ yarn start` spin a webpack development server, rather put it in the `dev` script; `start` should e.g. spawn [serve](https://github.com/zeit/serve).